### PR TITLE
[TASK] compatibility for CMS 7.6

### DIFF
--- a/Classes/Xclass/FileList.php
+++ b/Classes/Xclass/FileList.php
@@ -2,6 +2,8 @@
 
 namespace RENOLIT\ReintFilelistExtended\Xclass;
 
+use TYPO3\CMS\Filelist\Controller\FileListController;
+
 /* * *************************************************************
  *
  *  Copyright notice
@@ -29,8 +31,13 @@ namespace RENOLIT\ReintFilelistExtended\Xclass;
 
 class FileList extends \TYPO3\CMS\Filelist\FileList {
 
-	public function __construct() {
-		parent::__construct();
+	/**
+	 * Construct
+	 *
+	 * @param FileListController $fileListController
+	 */
+	public function __construct(FileListController $fileListController) {
+		parent::__construct($fileListController);
 
 		/*
 		 * settings from ext_conf_template.txt


### PR DESCRIPTION
Filelist modul in CMS 7.6 backend is broken, cause of missing argument in extended classes constructor method.